### PR TITLE
NO SEMANTIC CHANGE, purely code improvement + fix test

### DIFF
--- a/packages/application/src/api/json-rpc/responseHandlers.ts
+++ b/packages/application/src/api/json-rpc/responseHandlers.ts
@@ -73,9 +73,9 @@ const transactionIdentifierDecoder = (...keys: string[]) =>
 const networkDecoder = (...keys: string[]) =>
 	decoder((value, key) =>
 		key !== undefined && keys.includes(key) && typeof value === 'number'
-			? value !== 1
-				? ok(NetworkT.BETANET)
-				: ok(NetworkT.MAINNET)
+			? value === 1
+				? ok(NetworkT.MAINNET)
+				: ok(NetworkT.BETANET)
 			: undefined,
 	)
 

--- a/packages/application/test/json-rpc.test.ts
+++ b/packages/application/test/json-rpc.test.ts
@@ -133,7 +133,7 @@ const expectedDecodedResponses = {
 		response: NetworkIdEndpoint.Response,
 	): NetworkIdEndpoint.DecodedResponse => ({
 		networkId:
-			response.networkId === 0 ? NetworkT.MAINNET : NetworkT.BETANET,
+			response.networkId !== 1 ? NetworkT.BETANET : NetworkT.MAINNET,
 	}),
 
 	[rpcSpec.methods[1].name]: (


### PR DESCRIPTION
I claim that

```typescript
value !== 1 ? .BETANET : .MAINNET
```

Is the same thing as:


```typescript
value === 1 ? .MAINNET : .BETANET
```

But that the latter is easier to read because negation always bugs our feeble human's minds.