### PR TITLE
fix: Lookup TX Response invalid messages

### DIFF
--- a/packages/application/src/api/json-rpc/responseHandlers.ts
+++ b/packages/application/src/api/json-rpc/responseHandlers.ts
@@ -170,13 +170,19 @@ export const handleLookupTXResponse = (
 		.andThen(decoded =>
 			ok({
 				...decoded,
-				message: decoded.message
-					? Message.isPlaintext(decoded.message)
+				message: (() => {
+					if (!decoded.message) return undefined
+
+					// Check format
+					if (!/^(00|01)[0-9a-fA-F]+$/.test(decoded.message))
+						return '<Failed to interpret message>'
+
+					return Message.isPlaintext(decoded.message)
 						? Message.plaintextToString(
 								Buffer.from(decoded.message, 'hex'),
 						  )
 						: decoded.message
-					: undefined,
+					})(),
 			}),
 		)
 


### PR DESCRIPTION
Applies the changes to `handleTransactionHistoryResponse` for invalid messages to the `handleLookupTXResponse` functionality.