### PR TITLE
fix: Relative Import of networking crashes wallet

### DIFF
--- a/packages/application/src/api/api.ts
+++ b/packages/application/src/api/api.ts
@@ -1,4 +1,4 @@
-import { openApiClient } from '../../../networking'
+import { openApiClient } from '@radixdlt/networking'
 import { getAPI } from './open-api/interface'
 
 export const nodeAPI = (url: URL) => ({


### PR DESCRIPTION
We're currently unable to build the wallet using the latest release
because of an error:

```
ERROR  Failed to compile with 1 error                                                                                                                                    11:16:21 AM

This relative module was not found:

* ../../../networking in ./node_modules/@radixdlt/application/dist/api/api.js
```

This PR replaces that relative import.