### PR TITLE
Move jest to dev dependencies

### DIFF
--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@open-rpc/mock-server": "1.7.2",
     "@open-rpc/schema-utils-js": "1.14.3",
-    "jest": "^26.6.3",
     "json-schema-faker": "^0.5.0-rcv.34",
     "neverthrow": "^4.0.1",
     "node-fetch": "^2.6.1",
@@ -44,7 +43,8 @@
     "@types/bignumber.js": "^5.0.0",
     "axios-mock-adapter": "^1.20.0",
     "bignumber.js": "^9.0.1",
-    "fetch-mock-jest": "^1.5.1"
+    "fetch-mock-jest": "^1.5.1",
+    "jest": "^26.6.3"
   },
   "gitHead": "f8026eb0c310402ba395025e6a544f7c6baffd66"
 }


### PR DESCRIPTION
When trying to use latest version of the package, `jest` being in deps produces error for end user.

```
 yarn add @radixdlt/application

error An unexpected error occurred: "expected workspace package to exist for \"@jest/core\"".
info If you think this is a bug, please open a bug report with the information provided in "yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```