### PR TITLE
fix: Ignore Active Address for HW Verification

### DIFF
--- a/packages/application/src/wallet.ts
+++ b/packages/application/src/wallet.ts
@@ -90,26 +90,10 @@ const create = (
 			signingKeychain.deriveHWSigningKey(input).pipe(map(skToAccount)),
 
 		displayAddressForActiveHWAccountOnHWDeviceForVerification: (): Observable<void> =>
-			observeActiveAccount().pipe(
-				mergeMap(
-					(a: AccountT): Observable<void> =>
-						signingKeychain
-							.__unsafeGetSigningKey()
-							.getPublicKeyDisplayOnlyAddress()
-							.pipe(
-								mergeMap(
-									(pk: PublicKeyT): Observable<void> => {
-										if (pk.equals(a.publicKey)) {
-											return of(undefined)
-										} else {
-											const errMsg = `Hardware wallet returned a different public key than the cached one, this is bad. Probably incorrect implementation.`
-											log.error(errMsg)
-											return throwError(new Error(errMsg))
-										}
-									},
-								),
-							),
-				),
+			signingKeychain.__unsafeGetSigningKey().getPublicKeyDisplayOnlyAddress().pipe(mergeMap(
+				(): Observable<void> => {
+					return of(undefined)
+				})
 			),
 
 		observeActiveAccount,


### PR DESCRIPTION
Now that there is support for multiple hardware ledgers with multiple hardware accounts in the olympia wallet, there is a bug where after making significant wallet changes (so that the `wallet` and `activeAccount` observables have multiple ... events...), the 'verify' SDK ie: `displayAddressForActiveHWAccountOnHWDeviceForVerification` function fires multiple requests to the `sendAPDU` tunnel with the same message.  This seems to be from the dependence on the `activeAccount` observable, which I've removed.  This PR removes that dependency and fixes the bug.

Because the wallet no longer depends on `radix.activeAccount` as the source of the account that is being viewed(because it can now view the details of a linked hardware account from the public ledger (ie `radix.ledger.*` functions) that are not necessarily actively connected, it seems that these values collide / conflict / cause a problem where the `sendAPDU` and the connect ledger receive many duplicated messages.