### PR TITLE
fix: Signing Keychain sending multiple signals

### DIFF
--- a/packages/account/src/signingKeychain.ts
+++ b/packages/account/src/signingKeychain.ts
@@ -190,6 +190,7 @@ const create = (
 			input.keyDerivation === 'next' ? nextPath() : input.keyDerivation
 
 		return input.hardwareWalletConnection.pipe(
+			take(1),
 			mergeMap(
 				(
 					hardwareWallet: HardwareWalletT,


### PR DESCRIPTION
Now that the Olympia Wallet has the ability to manage multiple hardware ledgers, the wallet consistently calls `radix.deriveHWAccount` which requires that we pass in the `hardwareWalletConnection` observable down.

If this observable changes, (still not sure under what circumstances this happens, but happens consistently when adding a new account on a ledger) future actions end up sending multiple, duplicate signals through the hardware connection.  This messaging to different addresses seems to cause occasional race conditions and strange behavior (especially when sending transactions with encrypted messages) about 5% of the time.

There's probably a nicer way of doing this.  My understanding of the intent of `HardwareWalletLedger` is that we probably only need a single instance, and could remove it from the signature of `deriveHWAccount` but I lack the knowledge of the specifics in the SDK. ie:

```typescript
const hardwareWalletConnection = HardwareWalletLedger.create({
  send: sendAPDU
})
radix.setHardwareWallet(hardwareWalletConnection)
radix.deriveHWAccount({
...
})
```