### PR TITLE
fix: Calculate Shared Secret

### DIFF
--- a/packages/crypto/src/encryption/messageEncryption.ts
+++ b/packages/crypto/src/encryption/messageEncryption.ts
@@ -41,7 +41,9 @@ const calculateSharedSecret = (
 	return diffieHellmanPoint().map((dhKey: ECPointOnCurveT) => {
 		const ephemeralPoint = input.ephemeralPublicKey.decodeToPointOnCurve()
 		const sharedSecretPoint = dhKey.add(ephemeralPoint)
-		return Buffer.from(sharedSecretPoint.x.toString(16), 'hex')
+		const buf = Buffer.alloc(32)
+		buf.write(sharedSecretPoint.x.toString(16), 'hex')
+		return buf
 	})
 }
 


### PR DESCRIPTION
There's been a long standing bug in the SDK that occurs when handling
encrypted messages.  Thanks to the great debugging from the Radix
community discord, we were able to figure out whats going on and write a
simple fix to the problem.  Sometimes the shared secret calculation
returns a buffer of an unexpected length, this little fix sets the
buffers length explicitly.