### PR TITLE
Changing node engine versions limits

### DIFF
--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/radixdlt/radixdlt-javascript/issues"
   },
   "engines": {
-    "node": ">=15.5.0 <16"
+    "node": ">=15.5.0 <18"
   },
   "dependencies": {
     "@radixdlt/crypto": "^2.1.13",


### PR DESCRIPTION
Currently is 16, moving limit to version 18.