### PR TITLE
fix: Allocating a buffer to a fixed size does not pad it's contents

### DIFF
--- a/packages/crypto/src/encryption/messageEncryption.ts
+++ b/packages/crypto/src/encryption/messageEncryption.ts
@@ -41,8 +41,9 @@ const calculateSharedSecret = (
 	return diffieHellmanPoint().map((dhKey: ECPointOnCurveT) => {
 		const ephemeralPoint = input.ephemeralPublicKey.decodeToPointOnCurve()
 		const sharedSecretPoint = dhKey.add(ephemeralPoint)
+		const data = sharedSecretPoint.x.toString(16)
 		const buf = Buffer.alloc(32)
-		buf.write(sharedSecretPoint.x.toString(16), 'hex')
+		buf.write(data.padStart(64, '0'), 'hex')
 		return buf
 	})
 }


### PR DESCRIPTION
As the title says, we were still running into issues with hex errors despite the fix in #204.  This tiny change actually pads the content of the buffer with 0s correctly.  Tested locally over 30 transactions with encrypted messages (which currently calls this function twice per transaction) and ledger devices and had zero errors.